### PR TITLE
added 0 check before dividing by delta

### DIFF
--- a/src/de/ur/mi/oop/app/AppManager.java
+++ b/src/de/ur/mi/oop/app/AppManager.java
@@ -77,7 +77,7 @@ public class AppManager implements ConfigChangeListener, ActionListener, KeyList
     public void actionPerformed(ActionEvent e) {
         long currentTime = System.currentTimeMillis();
         long delta = currentTime - lastFrameTime;
-        if (delta != currentTime) {
+        if (delta != currentTime && delta != 0) {
             int currentFPS = 1000 / (int) delta;
             if (Math.abs(currentFPS - lastFPS) > 5) {
                 showFPS(currentFPS);


### PR DESCRIPTION
Die App kann crashen wenn actionPerformed() 2 mal in der selben millisekunde aufgerufen wird da delta den Wert 0 annehmen kann. Dieser 0 check soll das verhindern, ist aber NICHT getestet.