### PR TITLE
Cleanup, minor updates and some quality of life improvements

### DIFF
--- a/src/de/ur/mi/oop/app/AppManager.java
+++ b/src/de/ur/mi/oop/app/AppManager.java
@@ -77,7 +77,7 @@ public class AppManager implements ConfigChangeListener, ActionListener, KeyList
     public void actionPerformed(ActionEvent e) {
         long currentTime = System.currentTimeMillis();
         long delta = currentTime - lastFrameTime;
-        if (delta != currentTime) {
+        if (delta != currentTime && delta != 0) {
             int currentFPS = 1000 / (int) delta;
             if (Math.abs(currentFPS - lastFPS) > 5) {
                 showFPS(currentFPS);

--- a/src/de/ur/mi/oop/app/AppManager.java
+++ b/src/de/ur/mi/oop/app/AppManager.java
@@ -55,6 +55,7 @@ public class AppManager implements ConfigChangeListener, ActionListener, KeyList
         appFrame.setSize(config.getWidth(), config.getHeight());
         appFrame.setLocationRelativeTo(null);
         appFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        appFrame.setResizable(false);
         appFrame.add(canvas);
         canvas.addMouseListener(this);  // MouseListener auf Canvas, damit Koordinaten Titelleiste nicht beinhalten
         canvas.addMouseMotionListener(this);
@@ -107,6 +108,11 @@ public class AppManager implements ConfigChangeListener, ActionListener, KeyList
 
     @Override
     public void keyPressed(KeyEvent e) {
+        // Close GraphicsApp on ESCAPE
+        if(e.getKeyCode() == KeyEvent.VK_ESCAPE) {
+            appFrame.dispatchEvent(new WindowEvent(appFrame, WindowEvent.WINDOW_CLOSING));
+            return;
+        }
         KeyPressedEvent keyPressedEvent = (KeyPressedEvent) GraphicsAppKeyEvent.createKeyEventFromAWT(e, KeyEventType.PRESSED);
         ((GraphicsAppKeyListener) app).onKeyPressed(keyPressedEvent);
     }

--- a/src/de/ur/mi/oop/app/Config.java
+++ b/src/de/ur/mi/oop/app/Config.java
@@ -6,7 +6,7 @@ import de.ur.mi.oop.colors.Colors;
 /**
  * Basiskonfiguration der GraphicsApp-Anwendung
  */
-// TODO: Config is shared by App and AppManager. Check if any safety issues occur by allowing both sides to change the object.
+
 public class Config {
 
     private static final int DEFAULT_WIDTH = 1280;

--- a/src/de/ur/mi/oop/app/GraphicsApp.java
+++ b/src/de/ur/mi/oop/app/GraphicsApp.java
@@ -86,7 +86,7 @@ public abstract class GraphicsApp extends GraphicsAppCore implements GraphicsApp
      */
     protected void drawBackground(Color color) {
         if (background == null) {
-            background = new Background();
+            background = new Background(getWidth(), getHeight());
         }
         background.setColor(color);
         background.draw();

--- a/src/de/ur/mi/oop/app/GraphicsAppCore.java
+++ b/src/de/ur/mi/oop/app/GraphicsAppCore.java
@@ -2,6 +2,7 @@ package de.ur.mi.oop.app;
 
 import de.ur.mi.oop.graphics.GraphicsObject;
 
+import java.lang.ref.Cleaner;
 import java.util.ArrayList;
 
 /**
@@ -10,7 +11,6 @@ import java.util.ArrayList;
 public class GraphicsAppCore {
 
     private static GraphicsAppCore app = null;
-    private ArrayList<GraphicsObject> objects;
     private ArrayList<GraphicsObject> drawBuffer;
     private Config config;
 
@@ -24,7 +24,6 @@ public class GraphicsAppCore {
         try {
             if (app == null) {
                 app = this;
-                objects = new ArrayList<>();
                 drawBuffer = new ArrayList<>();
             } else {
                 throw new OnlyOneGraphicsAppAllowedException();
@@ -46,25 +45,12 @@ public class GraphicsAppCore {
         return config;
     }
 
-    public GraphicsObject[] getObjects() {
-        // TODO: Think about passing copies of the objects!
-        return objects.toArray(new GraphicsObject[0]);
-    }
-
-    public void addObject(GraphicsObject object) {
-        objects.add(object);
-    }
-
-    public void removeObject(GraphicsObject object) {
-        objects.remove(object);
-    }
-
     public void addToDrawBuffer(GraphicsObject object) {
         drawBuffer.add(object);
     }
 
     public GraphicsObject[] getDrawBuffer() {
-        // TODO: Think about passing copies of the objects!
+        // TODO Think about passing copies of the objects!
         return drawBuffer.toArray(new GraphicsObject[0]);
     }
 

--- a/src/de/ur/mi/oop/graphics/Background.java
+++ b/src/de/ur/mi/oop/graphics/Background.java
@@ -1,15 +1,12 @@
 package de.ur.mi.oop.graphics;
 
-import de.ur.mi.oop.app.GraphicsApp;
-
 /**
  * Hintergrund-Objekt für die GraphicsApp
  */
 public class Background extends Rectangle {
 
-    // TODO: Remove dependency to GraphicsApp by injecting correct width and height
-    public Background() {
-        super(0, 0, GraphicsApp.getApp().getWidth(), GraphicsApp.getApp().getHeight());
+    public Background(int width, int height) {
+        super(0, 0, width, height);
         this.type = GraphicsObjectType.BACKGROUND;
     }
 

--- a/src/de/ur/mi/oop/graphics/Compound.java
+++ b/src/de/ur/mi/oop/graphics/Compound.java
@@ -103,7 +103,7 @@ public class Compound extends GraphicsObject {
         backgroundRectangle.setColor(this.getColor());
     }
 
-    // TODO: add possibility of transparent background rectangle with only stroke
+    // TODO: Add possibility of transparent background rectangle with only stroke
     private void drawBackground() {
         if (backgroundRectangle != null) {
             GraphicsApp.getApp().addToDrawBuffer(backgroundRectangle);

--- a/src/de/ur/mi/oop/graphics/GraphicsObject.java
+++ b/src/de/ur/mi/oop/graphics/GraphicsObject.java
@@ -45,7 +45,6 @@ public abstract class GraphicsObject {
         this.strokeWeight = 0;
         this.strokeColor = DEFAULT_BORDER_COLOR;
         this.type = GraphicsObjectType.NONE;
-        GraphicsApp.getApp().addObject(this);
     }
 
     public GraphicsObject(float x, float y) {
@@ -314,11 +313,5 @@ public abstract class GraphicsObject {
         double dx = object.getXPos() - this.getXPos();
         double dy = object.getYPos() - this.getYPos();
         return Math.sqrt(dx * dx + dy * dy);
-    }
-
-    @Override
-    protected void finalize() throws Throwable {
-        super.finalize();
-        GraphicsApp.getApp().removeObject(this);
     }
 }

--- a/src/de/ur/mi/oop/launcher/GraphicsAppLauncher.java
+++ b/src/de/ur/mi/oop/launcher/GraphicsAppLauncher.java
@@ -13,6 +13,16 @@ public class GraphicsAppLauncher {
 
     public static final String PACKAGE_DELIMITER = ".";
 
+    public static void launch() {
+        // TODO Find way to move stack tracing to getGraphicsAppInstance() to reduce load time
+        StackTraceElement[] stackTraceElements = new Exception().getStackTrace();
+        String launcherName = stackTraceElements[stackTraceElements.length - 1].getClassName();
+        if(launcherName.contains(PACKAGE_DELIMITER)) {
+            launcherName = launcherName.substring(launcherName.lastIndexOf(PACKAGE_DELIMITER)+1);
+        }
+        launch(launcherName);
+    }
+
     public static void launch(String appName) {
         Config config = new Config();
         launch(appName, config);
@@ -37,17 +47,16 @@ public class GraphicsAppLauncher {
     private static GraphicsApp getGraphicsAppInstance(String appName) throws ClassNotFoundException, IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
         StackTraceElement[] stackTraceElements = new Exception().getStackTrace();
         String launcherName = stackTraceElements[stackTraceElements.length - 1].getClassName();
-
         String className;
-
         int packageNameCutOffIndex = launcherName.lastIndexOf(PACKAGE_DELIMITER);
-        if (packageNameCutOffIndex != -1) {
+        // If Launcher was called from GraphicsApp
+        if(packageNameCutOffIndex == -1) {
+            className = appName;
+        // If Launcher was called from outside GraphicsApp
+        } else {
             String packageName = launcherName.substring(0, launcherName.lastIndexOf(PACKAGE_DELIMITER));
             className = packageName + PACKAGE_DELIMITER + appName;
-        } else {
-            className = appName;
         }
-
         Class<?> appClass = Class.forName(className);
         return (GraphicsApp) appClass.getConstructor().newInstance();
     }


### PR DESCRIPTION
# UI
- Enable closing of running *GraphicsApp* with `ESC` key
- Disallow users from manual resizing a *GraphicsApp*'s `JFrame` (resizing from code is still possible)

# API changes
- Add option to start *GraphicsApp* from same class without mentioning class name (`GraphicsApp.launch()`)
- Remove unnecessary dependency between `Background` and `GraphicsApp`

# Fixes
- Fix bug where app would crash in certain situations when fps counter is used
- Remove unused object list from *GraphicsApp*
- Remove some outdated comments